### PR TITLE
Fix tooltip clipping

### DIFF
--- a/web/pages/globals.css
+++ b/web/pages/globals.css
@@ -5,3 +5,15 @@
 .light-border {
     @apply border-[1.5px] border-black border-opacity-10;
 }
+
+/* See: https://greywyvern.com/337 */
+.show-transition {
+    transition: visibility 0s linear 0.2s, opacity 0.2s linear 0s;
+}
+/* 
+Matches hovering over a div (e.g. the one containing whatever shows the tooltip) 
+and applies to its adjacent sibling satisfying class selector.
+*/
+div:hover + .show-transition {
+    transition: visibility 0s linear 0s, opacity 0.2s linear 0s;
+}

--- a/web/pages/review.tsx
+++ b/web/pages/review.tsx
@@ -72,13 +72,14 @@ const Review = () => {
         <ProtectedRoute>
             <div className="h-full flex p-4 space-x-4">
                 <PageSection
+                    className="grow"
                     articles={[
                         <SectionArticle titleBar="Review">
                             Hello
                         </SectionArticle>,
                         <SectionArticle
                             titleBar="Flashcards"
-                            className="overflow-scroll mb-4"
+                            className="overflow-y-scroll mb-4"
                         >
                             <div className="flex-grow space-y-2">
                                 {flashcards.map((f) => (

--- a/web/pages/review.tsx
+++ b/web/pages/review.tsx
@@ -73,12 +73,12 @@ const Review = () => {
             <div className="h-full flex p-4 space-x-4">
                 <PageSection
                     articles={[
-                        <SectionArticle titleBar="Review" className="w-full">
+                        <SectionArticle titleBar="Review">
                             Hello
                         </SectionArticle>,
                         <SectionArticle
                             titleBar="Flashcards"
-                            className="w-full pb-4"
+                            className="overflow-scroll mb-4"
                         >
                             <div className="flex-grow space-y-2">
                                 {flashcards.map((f) => (

--- a/web/src/components/PageSection.tsx
+++ b/web/src/components/PageSection.tsx
@@ -8,7 +8,7 @@ interface BackgroundIconProps {
 const BackgroundIcon: React.FC<BackgroundIconProps> = ({ icon }) => {
     return (
         <div className="opacity-100 rounded-lg absolute inset-0 overflow-clip">
-            <div className="absolute right-[-25px] bottom-[-60px] text-gray-800 opacity-10 z-0">
+            <div className="absolute right-[-25px] bottom-[-60px] text-gray-800 opacity-10">
                 {icon}
             </div>
         </div>
@@ -31,14 +31,14 @@ export const SectionArticle: React.FC<SectionArticleProps> = ({
     className,
 }) => {
     return (
-        <div className={" w-full " + className ?? ""}>
-            <div className="overflow-auto flex py-2 px-3 flex-col space-y-2 h-full relative">
-                <div className="inline-flex align-top items-center space-x-2">
+        <div className={" w-full " + (className ?? "")}>
+            <div className="flex py-2 px-3 flex-col h-full relative">
+                {bgIcon && <BackgroundIcon icon={bgIcon} />}
+                <div className="inline-flex align-top items-center space-x-2 pb-2">
                     {icon}
                     <h1 className="text-xl text-gray-800 w-full">{titleBar}</h1>
                 </div>
-                {bgIcon && <BackgroundIcon icon={bgIcon} />}
-                <div className="z-10 grow">{children}</div>
+                <div className="grow relative">{children}</div>
             </div>
         </div>
     );
@@ -78,7 +78,7 @@ const PageSection: React.FC<PageSectionProps> = ({
         ];
     }
     return (
-        <div className={" grow " + className ?? ""}>
+        <div className={" grow " + (className ?? "")}>
             <div className="bg-white rounded-lg flex flex-row h-full light-border ">
                 {articles.map((SectionArticle, i) => (
                     <React.Fragment key={i}>

--- a/web/src/components/PageSection.tsx
+++ b/web/src/components/PageSection.tsx
@@ -32,11 +32,11 @@ export const SectionArticle: React.FC<SectionArticleProps> = ({
 }) => {
     return (
         <div className={" w-full " + (className ?? "")}>
-            <div className="flex py-2 px-3 flex-col h-full relative">
+            <div className="h-full flex flex-col relative py-2 px-3">
                 {bgIcon && <BackgroundIcon icon={bgIcon} />}
-                <div className="inline-flex align-top items-center space-x-2 pb-2">
+                <div className="flex items-center space-x-2 pb-2">
                     {icon}
-                    <h1 className="text-xl text-gray-800 w-full">{titleBar}</h1>
+                    <h1 className="w-full text-xl text-gray-800">{titleBar}</h1>
                 </div>
                 <div className="grow relative">{children}</div>
             </div>
@@ -78,8 +78,8 @@ const PageSection: React.FC<PageSectionProps> = ({
         ];
     }
     return (
-        <div className={" grow " + (className ?? "")}>
-            <div className="bg-white rounded-lg flex flex-row h-full light-border ">
+        <div className={className ?? ""}>
+            <div className="h-full flex flex-row bg-white light-border rounded-lg ">
                 {articles.map((SectionArticle, i) => (
                     <React.Fragment key={i}>
                         {i > 0 ? (

--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -8,10 +8,9 @@ interface TooltipProps {
 
 const Tooltip: React.FC<TooltipProps> = ({ children, tooltip }) => {
     const [showTooltip, setShowTooltip] = useState(false);
-    const opacity = showTooltip ? "opacity-100 mt-2" : "opacity-0 mt-4";
 
     return (
-        <div className="relative">
+        <div className="relative z-10">
             <div
                 onMouseEnter={() => setShowTooltip(true)}
                 onMouseLeave={() => setShowTooltip(false)}
@@ -19,9 +18,14 @@ const Tooltip: React.FC<TooltipProps> = ({ children, tooltip }) => {
                 {children}
             </div>
             {/* Max width of 52 */}
-            <div className="w-52 flex justify-center absolute z-50 right-1/2 translate-x-1/2">
+            <div
+                className={`${
+                    showTooltip ? "opacity-100 visible" : "opacity-0 invisible"
+                } w-52 flex justify-center absolute right-1/2 translate-x-1/2 show-transition`}
+            >
                 <div
-                    className={`${opacity} drop-shadow-lg text-xs rounded-lg bg-gray-100 border border-black border-opacity-20 p-2 text-center transition-all select-none duration-200 ease-out`}
+                    className="
+                    drop-shadow-lg text-xs rounded-lg bg-gray-100 border border-black border-opacity-20 p-2 text-center select-none"
                 >
                     {tooltip}
                 </div>


### PR DESCRIPTION
Fixes various CSS issues including some which stemmed from PageSection refactor (and my unreliable testing!).

- Tooltip clipped over buttons below, now includes visibility in transition (if this came from refactor I'd be very surprised)
- Fixed clipping mask of background icon being above other elements preventing interaction
- Fixed background icon & tooltip creating scrolling overflow when they shouldn't
- Did some CSS cleanup - every style (tailwind class) should be able to justify itself