### PR TITLE
Fix possible error when setting up flipster with valid redirect URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This requires `sqlx-cli` to be installed (`cargo install sqlx-cli`)
 4. In `Realm Settings`, click on the `Login` tab, and choose desired settings (`User registration`, `Forgot password`, etc.)
 5. In `Clients`, click `Create` and name the client the same as in `.env` (`react-auth` by default)
 6. Turn on client authentication
-7. Put `http://localhost:5173` in `Valid redirect URIs` and `Web origins`
+7. Put `http://localhost:5173/*` in `Valid redirect URIs` `http://localhost:5173/` and `Web origins`
 8. Go to `Credentials` and copy the client secret into `.env` where it says `<client_secret>`
 9. To add Google login or similar, go to `Identity providers` and `Add provider`, then fill in the details
 


### PR DESCRIPTION
Setting `Valid redirect URIs` to `http://localhost:5173` (as described currently) in the flipster keycloak 'react-auth' client settings gives an error when logging in ('Invalid parameter: redirect_uri'). This is fixed simply via addition of wildcard from root. The readme should specify this but not use a wildcard for `Web origins` (this also crashes when logging in, net::ERR_FAILED 200).