### PR TITLE
Error when incorrectly named

### DIFF
--- a/api/src/routes/folder.rs
+++ b/api/src/routes/folder.rs
@@ -166,7 +166,6 @@ pub async fn add_folder(
     payload: web::Json<SubFolderInsert>,
     req: HttpRequest,
 ) -> impl Responder {
-    // TODO: do not allow symbols?
     if !is_valid_folder_name(&payload.name) {
         return HttpResponse::BadRequest().body("Invalid folder name");
     }

--- a/web/src/components/routeFiles/IconView.tsx
+++ b/web/src/components/routeFiles/IconView.tsx
@@ -99,6 +99,10 @@ const IconView: React.FC<IconViewProps> = ({ currentPath }) => {
                     );
                     return false;
                 }
+                if (resp.status === 400) {
+                    alert("Failed to rename - Invalid folder name");
+                    return false;
+                }
 
                 refetch();
                 return true;


### PR DESCRIPTION
Not sure if this has been done in the best way but seems to work. Error displayed when folder name is left blank or there are any symbols as part of the name. Have only applied to the rename folder function on the front as my understanding is that this runs when a folder is added, just renames straight away?